### PR TITLE
👷(project) fix release title

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,10 +147,10 @@ jobs:
             if [[ "${RELEASE}" == "latest" ]]; then
               gh release delete -y "${RELEASE}" || true;
               git push origin ":${RELEASE}";
-              gh release create -F release.md -p "${RELEASE}" ./releases/*;
+              gh release create -F release.md -t "${RELEASE}" -p "${RELEASE}" ./releases/*;
             else
               if ! gh release list | grep "${RELEASE}"; then
-                gh release create -F release.md "${RELEASE}";
+                gh release create -F release.md -t "${RELEASE/v/}" "${RELEASE}";
               fi
               gh release upload --clobber "${RELEASE}" ./releases/*;
             fi


### PR DESCRIPTION
## Purpose

The default release title created via `gh` does not fit with our standards, _e.g._ `<release>: <commit title>` instead of `<release>`.

## Proposal

Add the `-t` option to the `gh release create` command.
