### PR TITLE
✨(videos) add video views counter panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Views, unique views and daily views panels in details Dashboard
+
+### Changed
+
+- Upgrade `Grafana` to 8.0.3
+
 ## [0.1.0] - 2021-06-22
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - env.d/postgresql
 
   grafana:
-    image: grafana/grafana:7.5.7
+    image: grafana/grafana:8.0.3
     ports:
       - 3000:3000
     user: "${DOCKER_USER:-1000}"


### PR DESCRIPTION
### Purpose

The video view count could be a useful indicator in the video details dashboard.

### Proposal

add two simple gauge panels to show the number of video views and and the number of distinct viewers.