### PR TITLE
✨(dashboard) add complete video views panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ### Added
 
+- Completion threshold metrics in details Dashboard
+- Complete views, unique complete views panels in details Dashboard
 - Views, unique views and daily views panels in details Dashboard
 
 ### Changed
@@ -22,5 +24,5 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Video details Dashboard
 
-[Unreleased]: https://github.com/openfun/postsie/v0.1.0...main
-[0.1.0]: https://github.com/openfun/postsie/1172535...v0.1.0
+[unreleased]: https://github.com/openfun/potsie/compare/v0.1.0...main
+[0.1.0]: https://github.com/openfun/potsie/compare/1172535...v0.1.0

--- a/src/dashboards/videos/details.jsonnet
+++ b/src/dashboards/videos/details.jsonnet
@@ -2,6 +2,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
 local dashboard = grafana.dashboard;
 local elasticsearch = grafana.elasticsearch;
 local graphPanel = grafana.graphPanel;
+local row = grafana.row;
 local statPanel = grafana.statPanel;
 local template = grafana.template;
 
@@ -9,16 +10,19 @@ local template = grafana.template;
 // Constants
 local lrs = 'lrs';
 local actor_account_name_field = 'actor.account.name.keyword';
+local context_extensions_completion_threshold_field = 'context.extensions.https://w3id.org/xapi/video/extensions/completion-threshold';
 local course_field = 'object.definition.extensions.http://adlnet.gov/expapi/activities/course.keyword';
 local result_extensions_time_field = 'result.extensions.https://w3id.org/xapi/video/extensions/time';
 local school_field = 'object.definition.extensions.https://w3id.org/xapi/acrossx/extensions/school.keyword';
 local session_field = 'object.definition.extensions.http://adlnet.gov/expapi/activities/module.keyword';
 local video_id_field = 'object.id.keyword';
+local verb_id_completed_value = 'http://adlnet.gov/expapi/verbs/completed';
+local verb_id_initialized_value = 'http://adlnet.gov/expapi/verbs/initialized';
 local verb_id_played_value = 'https://w3id.org/xapi/video/verbs/played';
+
 
 // Queries
 local video_id_query = 'object.id.keyword:$VIDEO';
-
 
 // Utils
 local double_escape_string(x) = std.strReplace(std.strReplace(x, ':', '\\\\:'), '/', '\\\\/');
@@ -93,48 +97,8 @@ dashboard.new(
   )
 )
 .addPanel(
-  graphPanel.new(
-    title='Verbs',
-    datasource=lrs,
-    bars=true,
-    lines=false,
-  ).addTarget(
-    elasticsearch.target(
-      datasource=lrs,
-      query=video_id_query,
-      metrics=[
-        {
-          id: '1',
-          type: 'count',
-        },
-      ],
-      bucketAggs=[
-        {
-          id: 'verb',
-          field: 'verb.display.en-US.keyword',
-          type: 'terms',
-          settings: {
-            order: 'desc',
-            orderBy: '_count',
-            min_doc_count: '0',
-            size: '0',
-          },
-        },
-        {
-          id: 'date',
-          field: 'timestamp',
-          type: 'date_histogram',
-          settings: {
-            interval: '1h',
-            min_doc_count: '0',
-            trimEdges: '0',
-          },
-        },
-      ],
-      timeField='timestamp'
-    )
-  ),
-  gridPos={ x: 0, y: 0, w: 12, h: 9 }
+  row.new(title='Views metrics', collapse=false),
+  gridPos={ x: 0, y: 0, w: 24, h: 1 }
 )
 .addPanel(
   statPanel.new(
@@ -149,6 +113,7 @@ dashboard.new(
     |||,
     datasource=lrs,
     reducerFunction='sum',
+    graphMode='none',
     unit='none'
   ).addTarget(
     elasticsearch.target(
@@ -179,46 +144,7 @@ dashboard.new(
       timeField='timestamp'
     )
   ),
-  gridPos={ x: 12, y: 0, w: 6, h: 9 }
-)
-.addPanel(
-  graphPanel.new(
-    title='Daily views',
-    description=|||
-      A view is counted when the user has clicked the play button in the interface
-      in the first ${VIEW_COUNT_THRESHOLD} seconds of the video.
-    |||,
-    datasource=lrs,
-  ).addTarget(
-    elasticsearch.target(
-      datasource=lrs,
-      query='%(video_query)s AND verb.id:"%(verb_played)s" AND %(time)s:[0 TO $VIEW_COUNT_THRESHOLD]' % {
-        video_query: video_id_query,
-        verb_played: verb_id_played_value,
-        time: single_escape_string(result_extensions_time_field),
-      },
-      metrics=[
-        {
-          id: '1',
-          type: 'count',
-        },
-      ],
-      bucketAggs=[
-        {
-          id: 'date',
-          field: 'timestamp',
-          type: 'date_histogram',
-          settings: {
-            interval: '1d',
-            min_doc_count: '0',
-            trimEdges: '0',
-          },
-        },
-      ],
-      timeField='timestamp'
-    )
-  ),
-  gridPos={ x: 12, y: 9, w: 12, h: 9 }
+  gridPos={ x: 0, y: 1, w: 4.8, h: 4.5 }
 )
 .addPanel(
   statPanel.new(
@@ -262,5 +188,213 @@ dashboard.new(
       timeField='timestamp'
     )
   ),
-  gridPos={ x: 18, y: 0, w: 6, h: 9 }
+  gridPos={ x: 4.8, y: 1, w: 4.8, h: 3 }
+)
+.addPanel(
+  statPanel.new(
+    title='Complete views',
+    description=|||
+      Total number of complete views of selected video. A view is considered as complete
+      when the completion threshold of the video has been reached.
+    |||,
+    datasource=lrs,
+    graphMode='none',
+    reducerFunction='sum',
+  ).addTarget(
+    elasticsearch.target(
+      datasource=lrs,
+      query='%(video_query)s AND verb.id:"%(verb_completed)s"' % {
+        video_query: video_id_query,
+        verb_completed: verb_id_completed_value,
+      },
+      metrics=[
+        {
+          id: '1',
+          type: 'count',
+        },
+      ],
+      bucketAggs=[
+        {
+          id: '5',
+          type: 'date_histogram',
+          settings: {
+            interval: 'auto',
+            min_doc_count: '0',
+            trimEdges: '0',
+          },
+        },
+      ],
+      timeField='timestamp'
+    )
+  ),
+  gridPos={ x: 0, y: 4, w: 4.8, h: 4.5 },
+)
+.addPanel(
+  statPanel.new(
+    title='Unique complete views',
+    description=|||
+      Total number of unique complete views of selected video.
+    |||,
+    datasource=lrs,
+    graphMode='none',
+    reducerFunction='sum',
+    unit='none',
+    fields='/^Unique Count$/'
+  ).addTarget(
+    elasticsearch.target(
+      datasource=lrs,
+      query='%(video_query)s AND verb.id:"%(verb_completed)s"' % {
+        video_query: video_id_query,
+        verb_completed: verb_id_completed_value,
+      },
+      metrics=[
+        {
+          id: '1',
+          type: 'cardinality',
+          field: actor_account_name_field,
+        },
+      ],
+      bucketAggs=[
+        {
+          id: '5',
+          field: actor_account_name_field,
+          type: 'terms',
+          settings: {
+            min_doc_count: '0',
+            size: '0',
+            order: 'desc',
+            orderBy: '_count',
+          },
+        },
+      ],
+      timeField='timestamp'
+    )
+  ),
+  gridPos={ x: 4.8, y: 3, w: 4.8, h: 3 },
+)
+.addPanel(
+  statPanel.new(
+    title='Completion threshold',
+    description=|||
+      Ratio of the video that needs to be seen to consider the video as completed.
+    |||,
+    datasource=lrs,
+    graphMode='none',
+    reducerFunction='max',
+    unit='none',
+    fields='/^Max context\\.extensions.https://w3id.org/xapi/video/extensions/completion\\-threshold$/'
+  ).addTarget(
+    elasticsearch.target(
+      datasource=lrs,
+      query='%(video_query)s AND verb.id:"%(verb_initialized)s"' % {
+        video_query: video_id_query,
+        verb_initialized: verb_id_initialized_value,
+      },
+      metrics=[
+        {
+          id: '1',
+          type: 'max',
+          field: context_extensions_completion_threshold_field,
+        },
+      ],
+      bucketAggs=[
+        {
+          id: '2',
+          type: 'date_histogram',
+          settings: {
+            interval: 'auto',
+          },
+        },
+      ],
+      timeField='timestamp'
+    )
+  ),
+  gridPos={ x: 4.8, y: 5, w: 4.8, h: 3 },
+)
+.addPanel(
+  graphPanel.new(
+    title='Daily views',
+    description=|||
+      A view is counted when the user has clicked the play button in the interface
+      in the first ${VIEW_COUNT_THRESHOLD} seconds of the video.
+    |||,
+    datasource=lrs,
+  ).addTarget(
+    elasticsearch.target(
+      datasource=lrs,
+      query='%(video_query)s AND verb.id:"%(verb_played)s" AND %(time)s:[0 TO $VIEW_COUNT_THRESHOLD]' % {
+        video_query: video_id_query,
+        verb_played: verb_id_played_value,
+        time: single_escape_string(result_extensions_time_field),
+      },
+      metrics=[
+        {
+          id: '1',
+          type: 'count',
+        },
+      ],
+      bucketAggs=[
+        {
+          id: 'date',
+          field: 'timestamp',
+          type: 'date_histogram',
+          settings: {
+            interval: '1d',
+            min_doc_count: '0',
+            trimEdges: '0',
+          },
+        },
+      ],
+      timeField='timestamp'
+    )
+  ),
+  gridPos={ x: 9.6, y: 1, w: 12, h: 9 }
+)
+.addPanel(
+  row.new(title='Event distributions', collapse=false),
+  gridPos={ x: 0, y: 7, w: 24, h: 1 }
+)
+.addPanel(
+  graphPanel.new(
+    title='Verbs',
+    datasource=lrs,
+    bars=true,
+    lines=false,
+  ).addTarget(
+    elasticsearch.target(
+      datasource=lrs,
+      query=video_id_query,
+      metrics=[
+        {
+          id: '1',
+          type: 'count',
+        },
+      ],
+      bucketAggs=[
+        {
+          id: 'verb',
+          field: 'verb.display.en-US.keyword',
+          type: 'terms',
+          settings: {
+            order: 'desc',
+            orderBy: '_count',
+            min_doc_count: '0',
+            size: '0',
+          },
+        },
+        {
+          id: 'date',
+          field: 'timestamp',
+          type: 'date_histogram',
+          settings: {
+            interval: '1h',
+            min_doc_count: '0',
+            trimEdges: '0',
+          },
+        },
+      ],
+      timeField='timestamp'
+    )
+  ),
+  gridPos={ x: 0, y: 8, w: 12, h: 9 }
 )


### PR DESCRIPTION
# Purpose

Teachers need to know how much is a video completely viewed. It helps to know about the relevance of the video in a course (if it needs to be reviewed, replaced or kept).

# Proposal

This panel shows the number of complete views for a specific video of a course session.

- [x] complete views
- [x] complete unique views
- [x] completion threshold metrics