### PR TITLE
✨(datasources) add datasource configuration for edxapp mysql database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ### Added
 
 - Video course and statements Dashboards
+- `mysql` datasource provisioning from edx app.
 - Video details dashboard new panel: video events distribution along the video
   timeline
 - Course video events distribution panel in details Dashboard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ### Added
 
 - Video course and statements Dashboards
-- `mysql` datasource provisioning from edx app.
+- Platform user in General Dashboard
+- `mysql` datasource provisioning from edx app
 - Video details dashboard new panel: video events distribution along the video
   timeline
 - Course video events distribution panel in details Dashboard

--- a/etc/grafana/provisioning/datasources/mysql.yaml
+++ b/etc/grafana/provisioning/datasources/mysql.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: edx_app
+    type: mysql
+    url: edx_mysql:3306
+    database: edxapp
+    user: edxapp_user
+    password: password

--- a/src/dashboards/platform/general.jsonnet
+++ b/src/dashboards/platform/general.jsonnet
@@ -1,0 +1,34 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local sql = grafana.sql;
+local statPanel = grafana.statPanel;
+local template = grafana.template;
+
+local edx_app = 'edx_app';
+
+dashboard.new(
+  'General',
+  editable=false,
+)
+.addPanel(
+  statPanel.new(
+    title='Platform user',
+    datasource=edx_app,
+    reducerFunction='distinctCount',
+    graphMode='none',
+    unit='none',
+    fields='/^username$/'
+  ).addTarget(
+    sql.target(
+      datasource=edx_app,
+      format='table',
+      rawSql='SELECT DISTINCT username FROM auth_user',
+    )
+  ),
+  gridPos={
+    h: 9,
+    w: 12,
+    x: 0,
+    y: 0,
+  },
+)


### PR DESCRIPTION
## Purpose

To get general platform statistics such as number of users, courses, enrollments... the database from edxapp has to be configured as a datasource.

# Proposal

- [x] add configuration for mysql edxapp (from learning-analytics-playground)
- [x] default dashboard to test consistency (number of users)

![platform_user](https://user-images.githubusercontent.com/56359895/124755822-1ba0a500-df2c-11eb-930f-ed6d290fe11b.png)
