### PR TITLE
Configure SSO with keycloak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ### Changed
 
 - Upgrade `Grafana` to 8.0.3
+- Move the elasticsearch data source to a datastream
 
 ## [0.1.0] - 2021-06-22
 

--- a/env.d/grafana
+++ b/env.d/grafana
@@ -8,6 +8,20 @@ GF_DATABASE_PASSWORD=pass
 # Auth
 GF_SECURITY_ADMIN_PASSWORD=pass
 
+# OAUTH
+GF_AUTH_GENERIC_OAUTH_ENABLED=true
+GF_AUTH_GENERIC_OAUTH_NAME=keycloak
+GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP=true
+GF_AUTH_GENERIC_OAUTH_CLIENT_ID=potsie
+GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=fa9e98ee-61a1-4092-8dac-1597da0c1bb0
+GF_AUTH_GENERIC_OAUTH_AUTH_URL=http://localhost:8080/auth/realms/fun-mooc/protocol/openid-connect/auth
+GF_AUTH_GENERIC_OAUTH_TOKEN_URL=http://keycloak:8080/auth/realms/fun-mooc/protocol/openid-connect/token
+GF_AUTH_GENERIC_OAUTH_API_URL=http://keycloak:8080/auth/realms/fun-mooc/protocol/openid-connect/userinfo
+GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH="contains(roles[*], 'admin') && 'Admin' || contains(roles[*], 'editor') && 'Editor' || 'Viewer'"
+GF_AUTH_GENERIC_OAUTH_SCOPES=openid
+GF_LOG_FILTERS="auth:debug"
+GF_DEFAULT_APP_MODE="development"
+
 # Plugins
 GF_PATHS_PLUGINS=/var/lib/grafana/plugins/
 GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=grafana-groupedbarchart-panel

--- a/etc/grafana/provisioning/datasources/elasticsearch.yaml
+++ b/etc/grafana/provisioning/datasources/elasticsearch.yaml
@@ -5,8 +5,8 @@ datasources:
     type: elasticsearch
     editable: false
     access: proxy
-    database: "statements-marsha-*"
+    database: "statements*"
     url: http://elasticsearch:9200
     jsonData:
       esVersion: 70
-      timeField: "timestamp"
+      timeField: "@timestamp"


### PR DESCRIPTION
## Purpose

Potsie's users are supposed to login to potsie using a SSO workflow thanks to the Keycloak platform. An example configuration to test locally this workflow would be warmly welcome.

## Proposal

- [x] add an example configuration using the [learning-analytics-playground](https://github.com/openfun/learning-analytics-playground/) project

## Remarks

1. This PR depends on: https://github.com/openfun/learning-analytics-playground/pull/10
2. Note that during this work, I also had to fix the ES data source configuration to fit with recent changes in the Ralph project (we now use datastreams).
