### PR TITLE
🐛(project) fix node permission issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,17 @@ DOCKER_USER          = $(DOCKER_UID):$(DOCKER_GID)
 COMPOSE              = DOCKER_USER=$(DOCKER_USER) docker-compose
 COMPOSE_RUN          = $(COMPOSE) run --rm
 
+# -- Node
+COMPOSE_RUN_NODE     = $(COMPOSE_RUN) node
+YARN                 = $(COMPOSE_RUN_NODE) yarn
+
 # -- Utils
 WAIT_DB              = $(COMPOSE_RUN) dockerize -wait tcp://postgresql:5432 -timeout 60s
 WAIT_GRAFANA         = $(COMPOSE_RUN) dockerize -wait http://grafana:3000 -timeout 60s
 
 # -- Targets
-sources := $(shell find src/ -type f -name '*.jsonnet')
-libraries := $(shell find src/ -type f -name '*.libsonnet')
+sources := $(shell find src -type f -name '*.jsonnet')
+libraries := $(shell find src -type f -name '*.libsonnet')
 targets := $(patsubst src/%.jsonnet,var/lib/grafana/%.json,$(sources))
 
 default: help
@@ -57,7 +61,7 @@ compile: ## compile jsonnet sources to json
 .PHONY: compile
 
 dependencies: ## install project dependencies (plugins)
-	@$(COMPOSE_RUN) node yarn install
+	@$(YARN) install
 .PHONY: dependencies
 
 down: ## remove stack (warning: it removes the database container)
@@ -77,7 +81,7 @@ logs: ## display grafana logs (follow mode)
 .PHONY: logs
 
 plugins: ## download, build and install plugins
-	@$(COMPOSE_RUN) node yarn build
+	@$(YARN) build
 .PHONY: plugins
 
 restart: ## restart grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,13 @@ services:
   node:
     image: node:14
     user: "${DOCKER_USER:-1000}"
+    # We must run node with a /home because yarn tries to write to ~/.yarnrc.
+    # If the ID of our host user (with which we run the container) does not
+    # exist in the container (e.g. 1000 exists but 1009 does not exist by
+    # default), then yarn will try to write to "/.yarnrc" at the root of the
+    # system and will fail with a permission error.
+    environment:
+      - HOME=/tmp
     working_dir: /src/plugins
     volumes:
       - ./src/plugins:/src/plugins


### PR DESCRIPTION
## Purpose

We must run node with a /home because yarn tries to write to ~/.yarnrc. If the ID of our host user (with which we run the container) does not exist in the container (e.g. 1000 exists but 1009 does not exist by default), then yarn will try to write to "/.yarnrc" at the root of the system and will fail with a permission error.

## Proposal

- [x] set `HOME` environment variable to `/tmp` in the node container
