### PR TITLE
⚡️(project) allow oauth authentication debugging

### DIFF
--- a/env.d/grafana
+++ b/env.d/grafana
@@ -18,8 +18,12 @@ GF_AUTH_GENERIC_OAUTH_AUTH_URL=http://localhost:8080/auth/realms/fun-mooc/protoc
 GF_AUTH_GENERIC_OAUTH_TOKEN_URL=http://keycloak:8080/auth/realms/fun-mooc/protocol/openid-connect/token
 GF_AUTH_GENERIC_OAUTH_API_URL=http://keycloak:8080/auth/realms/fun-mooc/protocol/openid-connect/userinfo
 GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH="contains(roles[*], 'admin') && 'Admin' || contains(roles[*], 'editor') && 'Editor' || 'Viewer'"
-GF_AUTH_GENERIC_OAUTH_SCOPES=openid
-GF_LOG_FILTERS="auth:debug"
+GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT=true
+GF_AUTH_GENERIC_OAUTH_TLS_SKIP_VERIFY_INSECURE=true
+GF_AUTH_GENERIC_OAUTH_SCOPES="openid"
+GF_LOG_FILTERS="oauth.generic_oauth:debug"
+# ⚠️ ⚠️   Activate debug level globally
+# GF_LOG_LEVEL="debug"
 GF_DEFAULT_APP_MODE="development"
 
 # Plugins


### PR DESCRIPTION
## Purpose

When roles fetching fails after an oauth authentication, it's hard to debug the authentication process.

## Proposal

- [x] Make role attributes strict so that logging fails if grafana cannot fetch user roles from the oauth service (keycloak)
- [x] Skip TLS verification for development
- [x] Increase log level
