### PR TITLE
🔥(project) Cleanup unnecessary code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,6 @@ run: ## start the development server
 	@$(COMPOSE) up -d grafana
 	@echo "Wait for grafana to be up..."
 	@$(WAIT_GRAFANA)
-	@$(COMPOSE) up -d app
 .PHONY: run
 
 status: ## an alias for "docker-compose ps"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,6 @@ services:
     build:
       context: .
     image: potsie:development
-    env_file:
-      - env.d/app
     user: "${DOCKER_USER:-1000}"
     volumes:
       - ./src/dashboards:/app/dashboards

--- a/env.d/app
+++ b/env.d/app
@@ -1,1 +1,0 @@
-GRAFANA_URL=http://admin:pass@grafana:3000


### PR DESCRIPTION
## Purpose

Remove unnecessary code in makefile and docker-compose

## Proposal

- [x] Remove `@$(COMPOSE) up -d app` in make:run. This command does nothing but building the container, as we do not provide a command to execute. Removing it speed up a little bit the `make:run` command.
- [x] Remove `env.d/app` file and clean `docker-compose.yaml`, as it contains only one variable, which is unused in the project

We could let an empty file `env.d/app` to use it as template if someone needs to register custom environment variable in the `app` container, but this can lead to a misunderstanding of the container execution requirements.

