### PR TITLE
Add temporary course key template

### DIFF
--- a/src/dashboards/common.libsonnet
+++ b/src/dashboards/common.libsonnet
@@ -6,6 +6,7 @@
     course: 'object.definition.extensions.http://adlnet.gov/expapi/activities/course.keyword',
     school: 'object.definition.extensions.https://w3id.org/xapi/acrossx/extensions/school.keyword',
     session: 'object.definition.extensions.http://adlnet.gov/expapi/activities/module.keyword',
+    course_key: 'context.contextActivities.parent.id.keyword',
   },
   metrics: {
     count: { id: '1', type: 'count' },

--- a/src/dashboards/videos/common.libsonnet
+++ b/src/dashboards/videos/common.libsonnet
@@ -21,6 +21,7 @@ local common = import '../common.libsonnet';
       school: common.utils.single_escape_string(common.fields.school),
       session: common.utils.single_escape_string(common.fields.session),
     },
+    course_key: 'context.contextActivities.parent.id.keyword',
     video_id: 'object.id.keyword:$VIDEO',
   },
   templates: {
@@ -33,6 +34,14 @@ local common = import '../common.libsonnet';
         course: common.fields.course,
         school: common.utils.double_escape_string(common.fields.school),
       },
+      refresh='time'
+    ),
+    course_key: template.new(
+      name='COURSE KEY',
+      current='all',
+      label='Courses Key',
+      datasource=$.datasources.lrs,
+      query='{"find": "terms", "field": "%(course_key)s"}' % { course_key: common.fields.course_key },
       refresh='time'
     ),
     event_group_interval: template.custom(

--- a/src/dashboards/videos/course.jsonnet
+++ b/src/dashboards/videos/course.jsonnet
@@ -17,6 +17,7 @@ dashboard.new(
 .addTemplate(video_common.templates.school)
 .addTemplate(video_common.templates.course)
 .addTemplate(video_common.templates.session)
+.addTemplate(video_common.templates.course_key)
 .addTemplate(video_common.templates.view_count_threshold)
 .addTemplate(video_common.templates.statements_interval)
 .addPanel(

--- a/src/dashboards/videos/details.jsonnet
+++ b/src/dashboards/videos/details.jsonnet
@@ -17,6 +17,7 @@ dashboard.new(
 .addTemplate(video_common.templates.school)
 .addTemplate(video_common.templates.course)
 .addTemplate(video_common.templates.session)
+.addTemplate(video_common.templates.course_key)
 .addTemplate(video_common.templates.video)
 .addTemplate(video_common.templates.view_count_threshold)
 .addTemplate(video_common.templates.event_group_interval)

--- a/src/dashboards/videos/statements.jsonnet
+++ b/src/dashboards/videos/statements.jsonnet
@@ -17,6 +17,7 @@ dashboard.new(
 .addTemplate(video_common.templates.school)
 .addTemplate(video_common.templates.course)
 .addTemplate(video_common.templates.session)
+.addTemplate(video_common.templates.course_key)
 .addTemplate(video_common.templates.statements_interval)
 .addPanel(
   statPanel.new(


### PR DESCRIPTION
# Purpose

The course identification in logs has evolved through the use of course key since August. Before, the {school, course, session} triplet allowed to identify the session course. However, all those information are also contained in the course key. 
Dashboard queries are mainly based on this three variables so the dashboard presentation will fail for logs generated after August.

# Proposal

As a temporary solution, the course key variable is added. According to the date time when the event is emitted, queries used for the dashboard are using either course key or school, course, session triplets.