### PR TITLE
🐛(provisioning) fix min count for course video statistics table

### DIFF
--- a/src/dashboards/teachers/course.jsonnet
+++ b/src/dashboards/teachers/course.jsonnet
@@ -622,7 +622,7 @@ dashboard.new(
             field: common.fields.video_id,
             id: '2',
             settings: {
-              min_doc_count: '0',
+              min_doc_count: '1',
               order: 'asc',
               orderBy: '_count',
               size: '0',
@@ -653,7 +653,7 @@ dashboard.new(
             field: common.fields.video_id,
             type: 'terms',
             settings: {
-              min_doc_count: '0',
+              min_doc_count: '1',
               order: 'desc',
               orderBy: '_count',
               size: '0',
@@ -680,7 +680,7 @@ dashboard.new(
             settings: {
               order: 'desc',
               orderBy: '_count',
-              min_doc_count: '0',
+              min_doc_count: '1',
               size: '0',
             },
           },
@@ -700,7 +700,7 @@ dashboard.new(
             field: common.fields.video_id,
             id: '2',
             settings: {
-              min_doc_count: '0',
+              min_doc_count: '1',
               order: 'desc',
               orderBy: '_count',
               size: '0',


### PR DESCRIPTION
# Purpose

The minimum count that can be displayed in the panel of the statistics table for the course overview table was set 0. For Grafana, a such setting implies to display results for all statements from the elasticsearch which does not fit to our expectations as the datasource contains all courses from the platform. 

# Proposal 

It has been set to 1 so that it fits to the request based on the course key and only displays data related to this key.