### PR TITLE
⚡️(datasource) fix demonstration courses datetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Fix demo date courses according to the current date
+
 ## [0.4.3] - 2022-04-07
 
 ### Fixed

--- a/fixtures/mysql/edxapp.sql
+++ b/fixtures/mysql/edxapp.sql
@@ -22,8 +22,8 @@ CREATE TABLE IF NOT EXISTS student_courseenrollment (
     `course_id` VARCHAR(255),
     `is_active` INT
 );
-INSERT INTO courses_course (id, `key`, `title`, `start_date`, `end_date`) VALUES (1, 'course-v1:FUN-MOOC+00001+session01', 'FUN Mooc Course 1 Session 1', DATE('2000-01-01'), DATE('2030-01-01'));
-INSERT INTO courses_course (id, `key`, `title`, `start_date`, `end_date`) VALUES (2, 'course-v1:FUN-MOOC+00002+session01', 'FUN Mooc Course 2 Session 2', DATE('2000-01-01'), DATE('2030-01-01'));
+INSERT INTO courses_course (id, `key`, `title`, `start_date`, `end_date`) VALUES (1, 'course-v1:FUN-MOOC+00001+session01', 'FUN Mooc Course 1 Session 1', DATE_SUB(NOW(),INTERVAL 2 MONTH), DATE_ADD(NOW(),INTERVAL 2 MONTH));
+INSERT INTO courses_course (id, `key`, `title`, `start_date`, `end_date`) VALUES (2, 'course-v1:FUN-MOOC+00002+session01', 'FUN Mooc Course 2 Session 2', DATE_SUB(NOW(),INTERVAL 2 MONTH), DATE_ADD(NOW(),INTERVAL 2 MONTH));
 INSERT INTO student_courseaccessrole (id, `user_id`, `course_id`, `role`) VALUES (1, 1, 'course-v1:FUN-MOOC+00001+session01', 'staff');
 INSERT INTO student_courseaccessrole (id, `user_id`, `course_id`, `role`) VALUES (2, 1, 'course-v1:FUN-MOOC+00002+session01', 'instructor');
 INSERT INTO auth_user (id, email, username) VALUES (1, 'teacher@example.org', 'teacher');


### PR DESCRIPTION
## Purpose

For now, the datetime of courses used in the demonstration were hard coded. As the demonstration will evolve among time, it was proper to adapt the start and end dates to the current datetime. 

## Proposal

They have been set with a 2-month delta thanks to [DATE_ADD and DATE_SUB functions from mysql](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-add).