### PR TITLE
Maintenance chores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Switch default Grafana theme to `light`
 - Upgrade `Grafana` to 8.5.2
+- Upgrade `elasticsearch` to 8.2.0
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ### Changed
 
 - Switch default Grafana theme to `light`
+- Upgrade `Grafana` to 8.5.2
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ fixtures: ## Load test data (for development)
 	@$(WAIT_MYSQL)
 	zcat ./fixtures/elasticsearch/lrs.json.gz | \
 	  $(COMPOSE_RUN) patch_statements_date | \
-	  $(COMPOSE_RUN) ralph push -b es --es-index statements-fixtures  && \
+	  $(COMPOSE_RUN) -T ralph push -b es --es-index statements-fixtures  && \
 	  $(COMPOSE_RUN) users-permissions sh /scripts/users-permissions.sh
 .PHONY: fixtures
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,10 +81,11 @@ services:
       - RALPH_ES_INDEX=statements
 
   elasticsearch:
-    image: elasticsearch:7.16.2
+    image: elasticsearch:8.2.0
     mem_limit: 2g
     environment:
       discovery.type: single-node
+      xpack.security.enabled: "false"
     ports:
       - "9200:9200"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ./fixtures/postgresql/marsha.sql:/docker-entrypoint-initdb.d/init.sql
 
   grafana:
-    image: grafana/grafana:8.3.3
+    image: grafana/grafana:8.5.2
     ports:
       - 3000:3000
     user: "${DOCKER_USER:-1000}"

--- a/scripts/users-permissions.sh
+++ b/scripts/users-permissions.sh
@@ -40,7 +40,7 @@ fi
 # Set "teacher" teams home dashboard
 TEACHER_HOME_DASHBOARD_ID=$(
     CURL \
-        "${BASE_URL}/api/search?query=Teachers%20home&type=dash-db" | \
+        "${BASE_URL}/api/search?tag=teacher&query=Home&type=dash-db" | \
     jq -r .[0].id
 )
 


### PR DESCRIPTION
## Purpose

We need to stay up-to-date in grafana/elasticsearch releases.

## Proposal

- [x] upgrade grafana to 8.5.2
- [x] upgrade elasticsearch to 8.2.0

During this work, I've also identified two bugs:

- [x] fix teachers home dashboard setting
- [x] fix docker-compose 2.x compatibility
