### PR TITLE
Fix average video views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ### Changed
 
 - Switch default Grafana theme to `light`
-- Upgrade `Grafana` to 8.5.2
+- Upgrade `Grafana` to 8.5.3
 - Upgrade `elasticsearch` to 8.2.0
 
 ### Fixed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ./fixtures/postgresql/marsha.sql:/docker-entrypoint-initdb.d/init.sql
 
   grafana:
-    image: grafana/grafana:8.5.2
+    image: grafana/grafana:8.5.3
     ports:
       - 3000:3000
     user: "${DOCKER_USER:-1000}"

--- a/etc/grafana/provisioning/datasources/elasticsearch.yaml
+++ b/etc/grafana/provisioning/datasources/elasticsearch.yaml
@@ -8,5 +8,5 @@ datasources:
     database: "statements*"
     url: http://elasticsearch:9200
     jsonData:
-      esVersion: 70
+      esVersion: '8.2.0'
       timeField: "@timestamp"


### PR DESCRIPTION
## Purpose

Average video views in the course videos overview dashboard are not properly calculated.

## Proposal

- [ ] fix aggregation query in the average video views panel from the course videos overview dashboard

During this work I also had to:

- [x] upgrade grafana to 8.5.3
- [x] fix interval aggregation parameter in ES8 queries
