### PR TITLE
⬆️(project) upgrade grafana to 9.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `Grafana` to 9.0.3
+
 ## [0.6.0] - 2022-05-31
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ./fixtures/postgresql/marsha.sql:/docker-entrypoint-initdb.d/init.sql
 
   grafana:
-    image: grafana/grafana:8.5.3
+    image: grafana/grafana:9.0.5
     ports:
       - 3000:3000
     user: "${DOCKER_USER:-1000}"


### PR DESCRIPTION
## Purpose

Multiple vulnerabilities have been detected in the version 8.5.3 :
https://www.cert.ssi.gouv.fr/avis/CERTFR-2022-AVI-649/

## Proposal

Upgrade grafana to the latest release:
https://github.com/grafana/grafana/releases/tag/v9.0.5