### PR TITLE
📝(project) update copyright holder

### DIFF
--- a/.gitlint.d/gitlint_emoji.py
+++ b/.gitlint.d/gitlint_emoji.py
@@ -28,7 +28,7 @@ class GitmojiTitle(LineRule):
         title contains one of them.
         """
         gitmojis = requests.get(
-            "https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json"
+            "https://raw.githubusercontent.com/carloscuesta/gitmoji/master/packages/gitmojis/src/gitmojis.json"
         ).json()["gitmojis"]
         emojis = [item["emoji"] for item in gitmojis]
         pattern = r"^({:s})\(.*\)\s[a-z].*$".format("|".join(emojis))

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-present GIP FUN MOOC.
+Copyright (c) 2021-present France Université Numérique
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/plugins/packages/stacked-barchart/LICENSE
+++ b/src/plugins/packages/stacked-barchart/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-present GIP FUN MOOC.
+Copyright (c) 2021-present France Université Numérique
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/plugins/packages/stacked-barchart/package.json
+++ b/src/plugins/packages/stacked-barchart/package.json
@@ -10,7 +10,7 @@
     "sign": "grafana-toolkit plugin:sign",
     "start": "yarn watch"
   },
-  "author": "GIP FUN MOOC",
+  "author": "France Université Numérique",
   "license": "MIT",
   "devDependencies": {
     "@grafana/data": "latest",

--- a/src/plugins/packages/stacked-barchart/src/plugin.json
+++ b/src/plugins/packages/stacked-barchart/src/plugin.json
@@ -6,7 +6,7 @@
   "info": {
     "description": "A stacked barchart panel",
     "author": {
-      "name": "GIP FUN MOOC",
+      "name": "France Université Numérique",
       "url": "https://github.com/openfun/"
     },
     "keywords": [


### PR DESCRIPTION
## Purpose

The GIP FUN-MOOC has been renamed France Université Numérique since a few years.

## Proposal

Replace each occurence of GIP FUN-MOOC with France Université Numérique
