### PR TITLE
Fix dashboard rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ### Changed
 
-- Upgrade `Grafana` to 9.0.3
+- Upgrade `Grafana` to 9.5.2
 
 ## [0.6.0] - 2022-05-31
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ./fixtures/postgresql/marsha.sql:/docker-entrypoint-initdb.d/init.sql
 
   grafana:
-    image: grafana/grafana:9.0.5
+    image: grafana/grafana:9.5.2
     ports:
       - 3000:3000
     user: "${DOCKER_USER:-1000}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,12 +73,12 @@ services:
       - ./scripts:/scripts
 
   ralph:
-    image: fundocker/ralph:latest
+    image: fundocker/ralph:3.6.0
     user: "${DOCKER_USER:-1000}"
     entrypoint: ["ralph"]
     environment:
-      - RALPH_ES_HOSTS=http://elasticsearch:9200
-      - RALPH_ES_INDEX=statements
+      - RALPH_BACKENDS__DATABASE__ES__HOSTS=http://elasticsearch:9200
+      - RALPH_BACKENDS__DATABASE__ES__INDEX=statements
 
   elasticsearch:
     image: elasticsearch:8.2.0


### PR DESCRIPTION
## Purpose

Dashboard rendering was failing as configuration for ralph service was
incorrect. Naming for environment variables has changed.

## Proposal

Fix environment variables names in Docker-compose.
Grafana has been upgraded too and ralph is now pinned to the last published
version (not latest anymore).
