### PR TITLE
🐛(provisioning) fix viewers computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Upgrade `Grafana` to 9.5.2
 
+### Fixed
+
+- Viewers computation was counting multiple times same viewers
+
 ## [0.6.0] - 2022-05-31
 
 ### Added

--- a/src/dashboards/teachers/course.jsonnet
+++ b/src/dashboards/teachers/course.jsonnet
@@ -219,9 +219,9 @@ dashboard.new(
     |||,
     datasource=common.datasources.lrs,
     graphMode='none',
-    reducerFunction='sum',
+    reducerFunction='count',
     unit='none',
-    fields='/^Unique Count$/'
+    fields='/^actor\\.account\\.name\\.keyword$/'
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
@@ -231,11 +231,11 @@ dashboard.new(
         time: common.utils.single_escape_string(teachers_common.fields.result_extensions_time),
         view_count_threshold: teachers_common.constants.view_count_threshold,
       },
-      metrics=[common.metrics.cardinality(common.fields.actor_account_name)],
+      metrics=[common.metrics.count],
       bucketAggs=[
         {
           id: 'name',
-          field: common.fields.video_id,
+          field: common.fields.actor_account_name,
           type: 'terms',
           settings: {
             order: 'desc',
@@ -319,9 +319,9 @@ dashboard.new(
     |||,
     datasource=common.datasources.lrs,
     graphMode='none',
-    reducerFunction='sum',
+    reducerFunction='count',
     unit='none',
-    fields='/^Unique Count$/'
+    fields='/^actor\\.account\\.name\\.keyword$/'
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
@@ -329,11 +329,11 @@ dashboard.new(
         course_videos: teachers_common.queries.course_videos,
         verb_completed: common.verb_ids.completed,
       },
-      metrics=[common.metrics.cardinality(common.fields.actor_account_name)],
+      metrics=[common.metrics.count],
       bucketAggs=[
         {
           id: '5',
-          field: common.fields.video_id,
+          field: common.fields.actor_account_name,
           type: 'terms',
           settings: {
             size: '0',


### PR DESCRIPTION
## Purpose

Viewers computation was summing the number of unique views per video in a given
course which gives sometimes a metric higher than the number of enrolled users
in a course !

## Proposal

Change the request to count the number of views grouped by
`actor.account.name.keyword` and apply the count reducer function on this field.

