### PR TITLE
Modify viewers aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## Changed
 
+- Upgrade `Grafana` to 10.1.0
 - Define `duration` and `title` panel for `Course video details` dashboard
 - Define a set of `downloads` panels for `Course video overview` dashboard
 - Modify the dashboards layout to a line display, grouping panels by theme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## Changed
+
+- Define `duration` and `title` panel for `Course video details` dashboard
+- Define a set of `downloads` panels for `Course video overview` dashboard
+- Modify the dashboards layout to a line display, grouping panels by theme
+
 ## [1.0.0] - 2023-07-20
 
 ### Changed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ./fixtures/postgresql/marsha.sql:/docker-entrypoint-initdb.d/init.sql
 
   grafana:
-    image: grafana/grafana:9.5.3
+    image: grafana/grafana:10.1.0
     ports:
       - 3000:3000
     user: "${DOCKER_USER:-1000}"

--- a/src/dashboards/common.libsonnet
+++ b/src/dashboards/common.libsonnet
@@ -15,6 +15,7 @@
     subtitle_language: 'context.extensions.https://w3id.org/xapi/video/extensions/cc-subtitle-lang.keyword',
     quality: 'context.extensions.https://w3id.org/xapi/video/extensions/quality',
     volume: 'context.extensions.https://w3id.org/xapi/video/extensions/volume',
+    parent_id: 'context.contextActivities.parent.id.keyword'
   },
   metrics: {
     count: { id: '1', type: 'count' },

--- a/src/dashboards/common.libsonnet
+++ b/src/dashboards/common.libsonnet
@@ -7,38 +7,47 @@
     marsha: 'marsha',
   },
   fields: {
-    actor_account_name: 'actor.account.name.keyword',
-    video_id: 'object.id',
-    subtitle_enabled: 'context.extensions.https://w3id.org/xapi/video/extensions/cc-subtitle-enabled',
-    full_screen: 'context.extensions.https://w3id.org/xapi/video/extensions/full-screen',
-    speed: 'context.extensions.https://w3id.org/xapi/video/extensions/speed.keyword',
-    subtitle_language: 'context.extensions.https://w3id.org/xapi/video/extensions/cc-subtitle-lang.keyword',
-    quality: 'context.extensions.https://w3id.org/xapi/video/extensions/quality',
-    volume: 'context.extensions.https://w3id.org/xapi/video/extensions/volume',
-    parent_id: 'context.contextActivities.parent.id.keyword'
-  },
-  metrics: {
-    count: { id: '1', type: 'count' },
-    cardinality(field):: {
-      id: '1',
-      type: 'cardinality',
-      field: field,
+    actor: {
+      account: {
+        name: 'actor.account.name.keyword',
+      },
     },
-    max(field):: {
-      id: '1',
-      type: 'max',
-      field: field,
+    object: {
+      id: 'object.id',
     },
-  },
-  objects: {
-    date_histogram(interval='auto', min_doc_count='1'):: {
-      id: 'date',
-      field: '@timestamp',
-      type: 'date_histogram',
-      settings: {
-        interval: interval,
-        min_doc_count: min_doc_count,
-        trimEdges: '0',
+    verb: {
+      display: {
+        en_US: 'verb.display.en-US.keyword',
+      },
+      id: {
+        completed: 'http://adlnet.gov/expapi/verbs/completed',
+        initialized: 'http://adlnet.gov/expapi/verbs/initialized',
+        played: 'https://w3id.org/xapi/video/verbs/played',
+        downloaded: 'http://id.tincanapi.com/verb/downloaded',
+        interacted: 'http://adlnet.gov/expapi/verbs/interacted',
+      },
+    },
+    context: {
+      contextActivities: {
+        parent: {
+          id: 'context.contextActivities.parent.id',
+        },
+      },
+      extensions: {
+        completion_threshold: 'context.extensions.https://w3id.org/xapi/video/extensions/completion-threshold',
+        subtitle_enabled: 'context.extensions.https://w3id.org/xapi/video/extensions/cc-subtitle-enabled',
+        full_screen: 'context.extensions.https://w3id.org/xapi/video/extensions/full-screen',
+        length: 'context.extensions.https://w3id.org/xapi/video/extensions/length',
+        speed: 'context.extensions.https://w3id.org/xapi/video/extensions/speed.keyword',
+        subtitle_language: 'context.extensions.https://w3id.org/xapi/video/extensions/cc-subtitle-lang.keyword',
+        quality: 'context.extensions.https://w3id.org/xapi/video/extensions/quality',
+        volume: 'context.extensions.https://w3id.org/xapi/video/extensions/volume',
+      },
+    },
+    result: {
+      extensions: {
+        length: 'result.extensions.https://w3id.org/xapi/video/extensions/length',
+        time: 'result.extensions.https://w3id.org/xapi/video/extensions/time',
       },
     },
   },
@@ -48,20 +57,9 @@
     video: 'video',
     xapi: 'xAPI',
   },
-  utils: {
-    double_escape_string(x):: std.strReplace(std.strReplace(std.strReplace(x, ':', '\\\\:'), '/', '\\\\/'), '-', '\\\\-'),
-    single_escape_string(x):: std.strReplace(std.strReplace(std.strReplace(x, ':', '\\:'), '/', '\\/'), '-', '\\-'),
-  },
   uids: {
     course_video_overview: '855bbd9f-09eb-42ac-aa5f-d0a2c6f8ee34',
     course_video_details: 'c6cc2218-4fea-4b4c-a622-245f3aa22893',
     teachers_home: '451f4aa3-d094-429e-ad87-4b6c809ffa35',
-  },
-  verb_ids: {
-    completed: 'http://adlnet.gov/expapi/verbs/completed',
-    initialized: 'http://adlnet.gov/expapi/verbs/initialized',
-    played: 'https://w3id.org/xapi/video/verbs/played',
-    downloaded: 'http://id.tincanapi.com/verb/downloaded',
-    interacted: 'http://adlnet.gov/expapi/verbs/interacted',
   },
 }

--- a/src/dashboards/teachers/course.jsonnet
+++ b/src/dashboards/teachers/course.jsonnet
@@ -20,11 +20,11 @@ dashboard.new(
 )
 .addLink(teachers_common.link.teacher)
 .addTemplate(teachers_common.templates.edx_course_key)
-.addTemplate(teachers_common.templates.title)
+.addTemplate(teachers_common.templates.course_title)
 .addTemplate(teachers_common.templates.start_date)
 .addTemplate(teachers_common.templates.end_date)
-.addTemplate(teachers_common.templates.course_video_ids)
-.addTemplate(teachers_common.templates.course_video_ids_with_uuid)
+.addTemplate(teachers_common.templates.course_videos_ids)
+.addTemplate(teachers_common.templates.course_videos_iris)
 .addPanel(
   text.new(
     title='Course title',
@@ -57,11 +57,11 @@ dashboard.new(
     elasticsearch.target(
       datasource=common.datasources.lrs,
       query=teachers_common.queries.course_videos,
-      metrics=[common.metrics.count],
+      metrics=[utils.metrics.count],
       bucketAggs=[
         {
           id: 'video',
-          field: common.fields.video_id,
+          field: common.fields.object.id,
           type: 'terms',
           settings: {
             min_doc_count: '1',
@@ -111,68 +111,36 @@ dashboard.new(
     elasticsearch.target(
       alias='Views',
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND verb.id:"%(verb_played)s" AND %(time)s:[0 TO %(view_count_threshold)s]' % {
+      query='%(course_videos)s AND %(views)s' % {
         course_videos: teachers_common.queries.course_videos,
-        verb_played: common.verb_ids.played,
-        time: common.utils.single_escape_string(teachers_common.fields.result_extensions_time),
-        view_count_threshold: teachers_common.constants.view_count_threshold,
+        views: teachers_common.queries.views,
       },
-      metrics=[common.metrics.count],
-      bucketAggs=[
-        {
-          id: 'date',
-          field: '@timestamp',
-          type: 'date_histogram',
-          settings: {
-            interval: '1d',
-            trimEdges: '0',
-          },
-        },
-      ],
+      metrics=[utils.metrics.count],
+      bucketAggs=[utils.aggregations.date_histogram(min_doc_count=0)],
       timeField='@timestamp'
     )
   ).addTarget(
     elasticsearch.target(
       alias='Complete views',
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND verb.id:"%(verb_completed)s"' % {
+      query='%(course_videos)s AND %(complete_views)s' % {
         course_videos: teachers_common.queries.course_videos,
-        verb_completed: common.verb_ids.completed,
+        complete_views: teachers_common.queries.complete_views,
       },
-      metrics=[common.metrics.count],
-      bucketAggs=[
-        {
-          id: 'date',
-          field: '@timestamp',
-          type: 'date_histogram',
-          settings: {
-            interval: '1d',
-            trimEdges: '0',
-          },
-        },
-      ],
+      metrics=[utils.metrics.count],
+      bucketAggs=[utils.aggregations.date_histogram(min_doc_count=0)],
       timeField='@timestamp'
     )
   ).addTarget(
     elasticsearch.target(
       alias='Downloads',
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND verb.id:"%(verb_downloaded)s"' % {
+      query='%(course_videos)s AND %(downloads)s' % {
         course_videos: teachers_common.queries.course_videos,
-        verb_downloaded: common.verb_ids.downloaded,
+        downloads: teachers_common.queries.downloads,
       },
-      metrics=[common.metrics.count],
-      bucketAggs=[
-        {
-          id: 'date',
-          field: '@timestamp',
-          type: 'date_histogram',
-          settings: {
-            interval: '1d',
-            trimEdges: '0',
-          },
-        },
-      ],
+      metrics=[utils.metrics.count],
+      bucketAggs=[utils.aggregations.date_histogram(min_doc_count=0)],
       timeField='@timestamp'
     )
   ),
@@ -195,14 +163,12 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND verb.id:"%(verb_played)s" AND %(time)s:[0 TO %(view_count_threshold)s]' % {
+      query='%(course_videos)s AND %(views)s' % {
         course_videos: teachers_common.queries.course_videos,
-        verb_played: common.verb_ids.played,
-        time: common.utils.single_escape_string(teachers_common.fields.result_extensions_time),
-        view_count_threshold: teachers_common.constants.view_count_threshold,
+        views: teachers_common.queries.views,
       },
-      metrics=[common.metrics.count],
-      bucketAggs=[common.objects.date_histogram('%(statements_interval)s' % { statements_interval: teachers_common.constants.statements_interval })],
+      metrics=[utils.metrics.count],
+      bucketAggs=[utils.aggregations.date_histogram()],
       timeField='@timestamp'
     )
   ),
@@ -222,17 +188,15 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND verb.id:"%(verb_played)s" AND %(time)s:[0 TO %(view_count_threshold)s]' % {
+      query='%(course_videos)s AND %(views)s' % {
         course_videos: teachers_common.queries.course_videos,
-        verb_played: common.verb_ids.played,
-        time: common.utils.single_escape_string(teachers_common.fields.result_extensions_time),
-        view_count_threshold: teachers_common.constants.view_count_threshold,
+        views: teachers_common.queries.views,
       },
-      metrics=[common.metrics.cardinality(common.fields.actor_account_name)],
+      metrics=[utils.metrics.cardinality(common.fields.actor.account.name)],
       bucketAggs=[
         {
           id: 'name',
-          field: common.fields.parent_id,
+          field: common.fields.context.contextActivities.parent.id,
           type: 'terms',
           settings: {
             order: 'desc',
@@ -259,17 +223,15 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND verb.id:"%(verb_played)s" AND %(time)s:[0 TO %(view_count_threshold)s]' % {
+      query='%(course_videos)s AND %(views)s' % {
         course_videos: teachers_common.queries.course_videos,
-        verb_played: common.verb_ids.played,
-        time: common.utils.single_escape_string(teachers_common.fields.result_extensions_time),
-        view_count_threshold: teachers_common.constants.view_count_threshold,
+        views: teachers_common.queries.views,
       },
-      metrics=[common.metrics.count],
+      metrics=[utils.metrics.count],
       bucketAggs=[
         {
           id: 'video',
-          field: common.fields.video_id,
+          field: common.fields.object.id,
           type: 'terms',
           settings: {
             order: 'desc',
@@ -297,12 +259,12 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND verb.id:"%(verb_completed)s"' % {
+      query='%(course_videos)s AND %(complete_views)s' % {
         course_videos: teachers_common.queries.course_videos,
-        verb_completed: common.verb_ids.completed,
+        complete_views: teachers_common.queries.complete_views,
       },
-      metrics=[common.metrics.count],
-      bucketAggs=[common.objects.date_histogram()],
+      metrics=[utils.metrics.count],
+      bucketAggs=[utils.aggregations.date_histogram()],
       timeField='@timestamp'
     )
   ),
@@ -322,15 +284,15 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND verb.id:"%(verb_completed)s"' % {
+      query='%(course_videos)s AND %(complete_views)s' % {
         course_videos: teachers_common.queries.course_videos,
-        verb_completed: common.verb_ids.completed,
+        complete_views: teachers_common.queries.complete_views,
       },
-      metrics=[common.metrics.cardinality(common.fields.actor_account_name)],
+      metrics=[utils.metrics.cardinality(common.fields.actor.account.name)],
       bucketAggs=[
         {
           id: '5',
-          field: common.fields.parent_id,
+          field: common.fields.context.contextActivities.parent.id,
           type: 'terms',
           settings: {
             size: '0',
@@ -361,11 +323,11 @@ dashboard.new(
         course_videos: teachers_common.queries.course_videos,
         verb_completed: common.verb_ids.completed,
       },
-      metrics=[common.metrics.count],
+      metrics=[utils.metrics.count],
       bucketAggs=[
         {
           id: 'name',
-          field: common.fields.video_id,
+          field: common.fields.object.id,
           type: 'terms',
           settings: {
             order: 'desc',
@@ -420,7 +382,7 @@ dashboard.new(
                 {
                   targetBlank: true,
                   title: 'View detailled insights about this video',
-                  url: '/d/%(course_video_details_uid)s/details?orgId=1&${EDX_COURSE_KEY:queryparam}&var-VIDEO=${__value.text}' % {
+                  url: '/d/%(course_video_details_uid)s/details?orgId=1&${EDX_COURSE_KEY:queryparam}&var-VIDEO_IRI=${__value.text}' % {
                     course_video_details_uid: common.uids.course_video_details,
                   },
                 },
@@ -497,7 +459,7 @@ dashboard.new(
       {
         bucketAggs: [
           {
-            field: common.fields.video_id,
+            field: common.fields.object.id,
             id: '2',
             settings: {
               min_doc_count: '1',
@@ -515,11 +477,9 @@ dashboard.new(
             type: 'count',
           },
         ],
-        query: '%(course_videos)s AND verb.id:"%(verb_played)s" AND %(time)s:[0 TO %(view_count_threshold)s]' % {
+        query: '%(course_videos)s AND %(views)s' % {
           course_videos: teachers_common.queries.course_videos,
-          verb_played: common.verb_ids.played,
-          time: common.utils.single_escape_string(teachers_common.fields.result_extensions_time),
-          view_count_threshold: teachers_common.constants.view_count_threshold,
+          views: teachers_common.queries.views,
         },
         refId: 'Videos views query',
         timeField: '@timestamp',
@@ -572,7 +532,7 @@ dashboard.new(
         bucketAggs: [
           {
             id: 'name',
-            field: common.fields.video_id,
+            field: common.fields.object.id,
             type: 'terms',
             settings: {
               min_doc_count: '1',
@@ -583,12 +543,10 @@ dashboard.new(
           },
         ],
         datasource: common.datasources.lrs,
-        metrics: [common.metrics.cardinality(common.fields.actor_account_name)],
-        query: '%(course_videos)s AND verb.id:"%(verb_played)s" AND %(time)s:[0 TO %(view_count_threshold)s]' % {
+        metrics: [utils.metrics.cardinality(common.fields.actor.account.name)],
+        query: '%(course_videos)s AND %(views)s' % {
           course_videos: teachers_common.queries.course_videos,
-          verb_played: common.verb_ids.played,
-          time: common.utils.single_escape_string(teachers_common.fields.result_extensions_time),
-          view_count_threshold: teachers_common.constants.view_count_threshold,
+          views: teachers_common.queries.views,
         },
         refId: 'Videos unique views query',
         timeField: '@timestamp',
@@ -597,7 +555,7 @@ dashboard.new(
         bucketAggs: [
           {
             id: 'name',
-            field: common.fields.video_id,
+            field: common.fields.object.id,
             type: 'terms',
             settings: {
               order: 'desc',
@@ -608,10 +566,10 @@ dashboard.new(
           },
         ],
         datasource: common.datasources.lrs,
-        metrics: [common.metrics.count],
-        query: '%(course_videos)s AND verb.id:"%(verb_completed)s"' % {
+        metrics: [utils.metrics.count],
+        query: '%(course_videos)s AND %(complete_views)s' % {
           course_videos: teachers_common.queries.course_videos,
-          verb_completed: common.verb_ids.completed,
+          complete_views: teachers_common.queries.complete_views,
         },
         refId: 'Videos complete views query',
         timeField: '@timestamp',
@@ -619,7 +577,7 @@ dashboard.new(
       {
         bucketAggs: [
           {
-            field: common.fields.video_id,
+            field: common.fields.object.id,
             id: '2',
             settings: {
               min_doc_count: '1',
@@ -631,10 +589,10 @@ dashboard.new(
           },
         ],
         datasource: common.datasources.lrs,
-        metrics: [common.metrics.cardinality(common.fields.actor_account_name)],
-        query: '%(course_videos)s AND verb.id:"%(verb_completed)s"' % {
+        metrics: [utils.metrics.cardinality(common.fields.actor.account.name)],
+        query: '%(course_videos)s AND %(complete_views)s' % {
           course_videos: teachers_common.queries.course_videos,
-          verb_completed: common.verb_ids.completed,
+          complete_views: teachers_common.queries.complete_views,
         },
         refId: 'Videos complete unique views query',
         timeField: '@timestamp',

--- a/src/dashboards/teachers/course.jsonnet
+++ b/src/dashboards/teachers/course.jsonnet
@@ -216,9 +216,9 @@ dashboard.new(
     |||,
     datasource=common.datasources.lrs,
     graphMode='none',
-    reducerFunction='count',
+    reducerFunction='sum',
     unit='none',
-    fields='/^actor\\.account\\.name\\.keyword$/'
+    fields='/^Unique Count$/'
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
@@ -228,11 +228,11 @@ dashboard.new(
         time: common.utils.single_escape_string(teachers_common.fields.result_extensions_time),
         view_count_threshold: teachers_common.constants.view_count_threshold,
       },
-      metrics=[common.metrics.count],
+      metrics=[common.metrics.cardinality(common.fields.actor_account_name)],
       bucketAggs=[
         {
           id: 'name',
-          field: common.fields.actor_account_name,
+          field: common.fields.parent_id,
           type: 'terms',
           settings: {
             order: 'desc',
@@ -316,9 +316,9 @@ dashboard.new(
     |||,
     datasource=common.datasources.lrs,
     graphMode='none',
-    reducerFunction='count',
+    reducerFunction='sum',
     unit='none',
-    fields='/^actor\\.account\\.name\\.keyword$/'
+    fields='/^Unique Count$/'
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
@@ -326,11 +326,11 @@ dashboard.new(
         course_videos: teachers_common.queries.course_videos,
         verb_completed: common.verb_ids.completed,
       },
-      metrics=[common.metrics.count],
+      metrics=[common.metrics.cardinality(common.fields.actor_account_name)],
       bucketAggs=[
         {
           id: '5',
-          field: common.fields.actor_account_name,
+          field: common.fields.parent_id,
           type: 'terms',
           settings: {
             size: '0',

--- a/src/dashboards/teachers/details.jsonnet
+++ b/src/dashboards/teachers/details.jsonnet
@@ -79,7 +79,7 @@ dashboard.new(
       bucketAggs=[
         {
           id: 'name',
-          field: common.fields.actor_account_name,
+          field: common.fields.parent_id,
           settings: {
             order: 'desc',
             orderBy: '_count',
@@ -145,7 +145,7 @@ dashboard.new(
       bucketAggs=[
         {
           id: '5',
-          field: common.fields.actor_account_name,
+          field: common.fields.parent_id,
           settings: {
             min_doc_count: '1',
             size: '0',

--- a/src/dashboards/teachers/details.jsonnet
+++ b/src/dashboards/teachers/details.jsonnet
@@ -41,20 +41,12 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query=teachers_common.queries.views,
-      metrics=[common.metrics.count],
-      bucketAggs=[
-        {
-          id: 'date',
-          field: '@timestamp',
-          settings: {
-            interval: '1d',
-            min_doc_count: '0',
-            trimEdges: '0',
-          },
-          type: 'date_histogram',
-        },
-      ],
+      query='%(video_iri)s AND %(views)s' % {
+        video_iri: teachers_common.queries.video_iri,
+        views: teachers_common.queries.views,
+      },
+      metrics=[utils.metrics.count],
+      bucketAggs=[utils.aggregations.date_histogram()],
       timeField='@timestamp'
     )
   ),
@@ -107,20 +99,12 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query=teachers_common.queries.complete_views,
-      metrics=[common.metrics.count],
-      bucketAggs=[
-        {
-          id: '5',
-          field: '@timestamp',
-          settings: {
-            interval: '1d',
-            min_doc_count: '0',
-            trimEdges: '0',
-          },
-          type: 'date_histogram',
-        },
-      ],
+      query='%(video_iri)s AND %(complete_views)s' % {
+        video_iri: teachers_common.queries.video_iri,
+        complete_views: teachers_common.queries.complete_views,
+      },
+      metrics=[utils.metrics.count],
+      bucketAggs=[utils.aggregations.date_histogram()],
       timeField='@timestamp'
     )
   ),
@@ -173,20 +157,12 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query=teachers_common.queries.downloads,
-      metrics=[common.metrics.count],
-      bucketAggs=[
-        {
-          id: 'date',
-          field: '@timestamp',
-          settings: {
-            interval: '1d',
-            min_doc_count: '0',
-            trimEdges: '0',
-          },
-          type: 'date_histogram',
-        },
-      ],
+      query='%(video_iri)s AND %(downloads)s' % {
+        video_iri: teachers_common.queries.video_iri,
+        downloads: teachers_common.queries.downloads,
+      },
+      metrics=[utils.metrics.count],
+      bucketAggs=[utils.aggregations.date_histogram()],
       timeField='@timestamp'
     )
   ),
@@ -326,7 +302,7 @@ dashboard.new(
       {
         bucketAggs: [
           {
-            field: teachers_common.fields.result_extensions_time,
+            field: common.fields.result.extensions.time,
             id: '2',
             settings: {
               interval: teachers_common.constants.event_group_interval,
@@ -335,7 +311,7 @@ dashboard.new(
             type: 'histogram',
           },
           {
-            field: teachers_common.fields.verb_display_en_us,
+            field: common.fields.verb.display.en_US,
             id: '3',
             settings: {
               min_doc_count: '0',
@@ -346,8 +322,8 @@ dashboard.new(
             type: 'terms',
           },
         ],
-        metrics: [common.metrics.count],
-        query: teachers_common.queries.video_id,
+        metrics: [utils.metrics.count],
+        query: teachers_common.queries.video_iri,
         refId: 'A',
         timeField: '@timestamp',
       },
@@ -365,8 +341,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query=teachers_common.queries.video_id,
-      metrics=[common.metrics.count],
+      query=teachers_common.queries.video_iri,
+      metrics=[utils.metrics.count],
       bucketAggs=[
         {
           id: 'verb',
@@ -379,16 +355,7 @@ dashboard.new(
             size: '0',
           },
         },
-        {
-          id: 'date',
-          field: '@timestamp',
-          type: 'date_histogram',
-          settings: {
-            interval: '1h',
-            min_doc_count: '0',
-            trimEdges: '0',
-          },
-        },
+        utils.aggregations.date_histogram(interval='1h', min_doc_count=0),
       ],
       timeField='@timestamp'
     )
@@ -408,14 +375,12 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(video_query)s' % {
-        video_query: teachers_common.queries.video_id,
-      },
-      metrics=[common.metrics.count],
+      query=teachers_common.queries.video_iri,
+      metrics=[utils.metrics.count],
       bucketAggs=[
         {
           id: '2',
-          field: teachers_common.fields.verb_display_en_us,
+          field: common.fields.verb.display.en_US,
           type: 'terms',
           settings: {
             order: 'asc',
@@ -424,16 +389,7 @@ dashboard.new(
             size: '0',
           },
         },
-        {
-          id: '3',
-          type: 'date_histogram',
-          field: '@timestamp',
-          settings: {
-            interval: 'auto',
-            min_doc_count: '0',
-            trimEdges: '0',
-          },
-        },
+        utils.aggregations.date_histogram(min_doc_count=0),
       ],
       timeField='@timestamp'
     )
@@ -451,22 +407,23 @@ dashboard.new(
       The number of learners who have activated the subtitles.
     |||,
     datasource=common.datasources.lrs,
-    fields=common.fields.actor_account_name,
+    fields=common.fields.actor.account.name,
     graphMode='none',
     reducerFunction='count',
     unit='none',
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(interacted_query)s AND %(subtitle_enabled)s:true' % {
-        interacted_query: teachers_common.queries.video_interacted,
-        subtitle_enabled: common.utils.single_escape_string(common.fields.subtitle_enabled),
+      query='%(video_iri)s AND %(interactions)s AND %(subtitle_enabled)s:true' % {
+        video_iri: teachers_common.queries.video_iri,
+        interactions: teachers_common.queries.interactions,
+        subtitle_enabled: utils.functions.single_escape_string(common.fields.context.extensions.subtitle_enabled),
       },
-      metrics=[common.metrics.count],
+      metrics=[utils.metrics.count],
       bucketAggs=[
         {
           id: '5',
-          field: common.fields.actor_account_name,
+          field: common.fields.actor.account.name,
           settings: {
             min_doc_count: '1',
             size: '0',
@@ -511,10 +468,11 @@ dashboard.new(
     targets: [
       {
         datasource: common.datasources.lrs,
-        query: '%(interacted_query)s' % {
-          interacted_query: teachers_common.queries.video_interacted,
+        query: '%(video_iri)s AND %(interactions)s' % {
+          video_iri: teachers_common.queries.video_iri,
+          interactions: teachers_common.queries.interactions,
         },
-        metrics: [common.metrics.cardinality(common.fields.actor_account_name)],
+        metrics: [utils.metrics.cardinality(common.fields.actor.account.name)],
         bucketAggs: [
           {
             id: '2',
@@ -525,7 +483,7 @@ dashboard.new(
               order: 'desc',
               orderBy: '_term',
             },
-            field: common.fields.subtitle_language,
+            field: common.fields.context.extensions.subtitle_language,
           },
         ],
         timeField: '@timestamp',
@@ -542,22 +500,23 @@ dashboard.new(
       The number of learners who have switched to full screen.
     |||,
     datasource=common.datasources.lrs,
-    fields=common.fields.actor_account_name,
+    fields=common.fields.actor.account.name,
     graphMode='none',
     reducerFunction='count',
     unit='none',
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(interacted_query)s AND %(full_screen)s:true' % {
-        interacted_query: teachers_common.queries.video_interacted,
-        full_screen: common.utils.single_escape_string(common.fields.full_screen),
+      query='%(video_iri)s AND %(interactions)s AND %(full_screen)s:true' % {
+        video_iri: teachers_common.queries.video_iri,
+        interactions: teachers_common.queries.interactions,
+        full_screen: utils.functions.single_escape_string(common.fields.context.extensions.full_screen),
       },
-      metrics=[common.metrics.count],
+      metrics=[utils.metrics.count],
       bucketAggs=[
         {
           id: '5',
-          field: common.fields.actor_account_name,
+          field: common.fields.actor.account.name,
           settings: {
             min_doc_count: '1',
             size: '0',
@@ -603,10 +562,11 @@ dashboard.new(
     targets: [
       {
         datasource: common.datasources.lrs,
-        query: '%(video_interacted)s' % {
-          video_interacted: teachers_common.queries.video_interacted,
+        query: '%(video_iri)s AND %(interactions)s' % {
+          video_iri: teachers_common.queries.video_iri,
+          interactions: teachers_common.queries.interactions,
         },
-        metrics: [common.metrics.cardinality(common.fields.actor_account_name)],
+        metrics: [utils.metrics.cardinality(common.fields.actor.account.name)],
         bucketAggs: [
           {
             id: '2',
@@ -617,7 +577,7 @@ dashboard.new(
               order: 'desc',
               orderBy: '_term',
             },
-            field: common.fields.speed,
+            field: common.fields.context.extensions.speed,
           },
         ],
         timeField: '@timestamp',
@@ -630,7 +590,7 @@ dashboard.new(
         options: {
           filters: [
             {
-              fieldName: common.fields.speed,
+              fieldName: common.fields.context.extensions.speed,
               config: {
                 id: 'equal',
                 options: {
@@ -678,10 +638,11 @@ dashboard.new(
     targets: [
       {
         datasource: common.datasources.lrs,
-        query: '%(interacted_query)s' % {
-          interacted_query: teachers_common.queries.video_interacted,
+        query: '%(video_iri)s AND %(interactions)s' % {
+          video_iri: teachers_common.queries.video_iri,
+          interactions: teachers_common.queries.interactions,
         },
-        metrics: [common.metrics.cardinality(common.fields.actor_account_name)],
+        metrics: [utils.metrics.cardinality(common.fields.actor.account.name)],
         bucketAggs: [
           {
             id: '2',
@@ -692,7 +653,7 @@ dashboard.new(
               order: 'desc',
               orderBy: '_term',
             },
-            field: common.fields.quality,
+            field: common.fields.context.extensions.quality,
           },
         ],
         timeField: '@timestamp',
@@ -705,7 +666,7 @@ dashboard.new(
         options: {
           conversions: [
             {
-              targetField: common.fields.quality,
+              targetField: common.fields.context.extensions.quality,
               destinationType: 'string',
             },
           ],
@@ -716,7 +677,7 @@ dashboard.new(
         options: {
           filters: [
             {
-              fieldName: common.fields.quality,
+              fieldName: common.fields.context.extensions.quality,
               config: {
                 id: 'equal',
                 options: {
@@ -750,7 +711,7 @@ dashboard.new(
         {
           matcher: {
             id: 'byName',
-            options: common.fields.volume,
+            options: common.fields.context.extensions.volume,
           },
           properties: [
             {
@@ -799,10 +760,11 @@ dashboard.new(
     targets: [
       {
         datasource: common.datasources.lrs,
-        query: '%(interacted_query)s' % {
-          interacted_query: teachers_common.queries.video_interacted,
+        query: '%(video_iri)s AND %(interactions)s' % {
+          video_iri: teachers_common.queries.video_iri,
+          interactions: teachers_common.queries.interactions,
         },
-        metrics: [common.metrics.cardinality(common.fields.actor_account_name)],
+        metrics: [utils.metrics.cardinality(common.fields.actor.account.name)],
         bucketAggs: [
           {
             id: '2',
@@ -813,7 +775,7 @@ dashboard.new(
               order: 'desc',
               orderBy: '_term',
             },
-            field: common.fields.volume,
+            field: common.fields.context.extensions.volume,
           },
         ],
         timeField: '@timestamp',
@@ -826,7 +788,7 @@ dashboard.new(
         options: {
           conversions: [
             {
-              targetField: common.fields.volume,
+              targetField: common.fields.context.extensions.volume,
               destinationType: 'string',
             },
           ],
@@ -837,7 +799,7 @@ dashboard.new(
         options: {
           filters: [
             {
-              fieldName: common.fields.volume,
+              fieldName: common.fields.context.extensions.volume,
               config: {
                 id: 'equal',
                 options: {

--- a/src/dashboards/utils.libsonnet
+++ b/src/dashboards/utils.libsonnet
@@ -1,0 +1,33 @@
+// General utils
+
+{
+  metrics: {
+    count: { id: '1', type: 'count' },
+    cardinality(field):: {
+      id: '1',
+      type: 'cardinality',
+      field: field,
+    },
+    max(field):: {
+      id: '1',
+      type: 'max',
+      field: field,
+    },
+  },
+  aggregations: {
+    date_histogram(interval='1d', min_doc_count='1'):: {
+      id: 'date',
+      field: '@timestamp',
+      type: 'date_histogram',
+      settings: {
+        interval: interval,
+        min_doc_count: min_doc_count,
+        trimEdges: '0',
+      },
+    },
+  },
+  functions: {
+    double_escape_string(x):: std.strReplace(std.strReplace(std.strReplace(x, ':', '\\\\:'), '/', '\\\\/'), '-', '\\\\-'),
+    single_escape_string(x):: std.strReplace(std.strReplace(std.strReplace(x, ':', '\\:'), '/', '\\/'), '-', '\\-'),
+  },
+}


### PR DESCRIPTION
## Purpose

Until now, an user aggregation was used for viewers metric computation. But with
elasticsearch datasource type, the count reducer function is limited to 500
inputs. Nevertheless, lots of videos count more than 500 users.

## Proposal 
To overcome this bug from elasticsearch, the cardinality metric is applied on viewed 
statements and the aggregation is made on `context.contextActivities.parent.id`
(i.e. course session ID).

