### PR TITLE
Fix "user sync failed" login bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## Added
+
+- Enable email lookup for Keycloak-OAuth
+
 ## [1.2.0] - 2024-02-21
 
 ### Changed

--- a/env.d/grafana
+++ b/env.d/grafana
@@ -10,17 +10,20 @@ GF_SECURITY_ADMIN_PASSWORD=pass
 
 # OAUTH
 GF_AUTH_GENERIC_OAUTH_ENABLED=true
-GF_AUTH_GENERIC_OAUTH_NAME=keycloak
+GF_AUTH_GENERIC_OAUTH_NAME=Keycloak-OAuth
 GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP=true
 GF_AUTH_GENERIC_OAUTH_CLIENT_ID=potsie
 GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=fa9e98ee-61a1-4092-8dac-1597da0c1bb0
+GF_AUTH_GENERIC_OAUTH_SCOPES="openid"
+GF_AUTH_GENERIC_OAUTH_EMAIL_ATTRIBUTE_PATH="email"
+GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH="username"
+GF_AUTH_GENERIC_OAUTH_NAME_ATTRIBUTE_PATH="full_name"
 GF_AUTH_GENERIC_OAUTH_AUTH_URL=http://localhost:8080/auth/realms/fun-mooc/protocol/openid-connect/auth
 GF_AUTH_GENERIC_OAUTH_TOKEN_URL=http://keycloak:8080/auth/realms/fun-mooc/protocol/openid-connect/token
 GF_AUTH_GENERIC_OAUTH_API_URL=http://keycloak:8080/auth/realms/fun-mooc/protocol/openid-connect/userinfo
 GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH="contains(roles[*], 'admin') && 'Admin' || contains(roles[*], 'editor') && 'Editor' || 'Viewer'"
 GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT=true
-GF_AUTH_GENERIC_OAUTH_TLS_SKIP_VERIFY_INSECURE=true
-GF_AUTH_GENERIC_OAUTH_SCOPES="openid"
+GF_AUTH_OAUTH_ALLOW_INSECURE_EMAIL_LOOKUP=true
 GF_LOG_FILTERS="oauth.generic_oauth:debug"
 # ⚠️ ⚠️   Activate debug level globally
 # GF_LOG_LEVEL="debug"


### PR DESCRIPTION
## Purpose

When deploying latest release of Potsie (with Grafana 10.X), the following error messages appears when signing in: `Login Failed - User sync failed`. 

## Proposal 

It seems that it is due to a patch made in 10.1 release to fix a security issue. A configuration flag is necessary to get user sync from Keycloak auth provider.
See security issue documentation: https://grafana.com/blog/2023/06/22/grafana-security-release-for-cve-2023-3128/
