### PR TITLE
🔒️(provisioning) restrict video analytics to current course context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Restrict video analytics to current course context
+
 ## [1.2.1] - 2024-03-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ $ make run
 
 After a few seconds, the application should be running at
 [localhost:3000](http://localhost:3000). Default admin credentials are
-`admin:pass`. Once logged in, running grafana instance should be provisioned
+`admin:pass`. If you want to see the provisionned dashboards, connect with the user `teacher:funfunfun`.
+Once logged in, running grafana instance should be provisioned
 with all dashboards versioned in this repository.
 
 ## Developer guide

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   postgresql:
     image: postgres:13.3

--- a/src/dashboards/teachers/course.jsonnet
+++ b/src/dashboards/teachers/course.jsonnet
@@ -81,7 +81,10 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query=teachers_common.queries.course_videos,
+      query='%(course_key)s AND %(course_videos)s' % {
+        course_key: teachers_common.queries.course_key,
+        course_videos: teachers_common.queries.course_videos,
+      },
       metrics=[utils.metrics.count],
       bucketAggs=[
         {
@@ -124,7 +127,8 @@ dashboard.new(
     elasticsearch.target(
       alias='Views',
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND %(views)s' % {
+      query='%(course_key)s AND %(course_videos)s AND %(views)s' % {
+        course_key: teachers_common.queries.course_key,
         course_videos: teachers_common.queries.course_videos,
         views: teachers_common.queries.views,
       },
@@ -136,7 +140,8 @@ dashboard.new(
     elasticsearch.target(
       alias='Complete views',
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND %(complete_views)s' % {
+      query='%(course_key)s AND %(course_videos)s AND %(complete_views)s' % {
+        course_key: teachers_common.queries.course_key,
         course_videos: teachers_common.queries.course_videos,
         complete_views: teachers_common.queries.complete_views,
       },
@@ -148,7 +153,8 @@ dashboard.new(
     elasticsearch.target(
       alias='Downloads',
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND %(downloads)s' % {
+      query='%(course_key)s AND %(course_videos)s AND %(downloads)s' % {
+        course_key: teachers_common.queries.course_key,
         course_videos: teachers_common.queries.course_videos,
         downloads: teachers_common.queries.downloads,
       },
@@ -176,7 +182,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND %(views)s' % {
+      query='%(course_key)s AND %(course_videos)s AND %(views)s' % {
+        course_key: teachers_common.queries.course_key,
         course_videos: teachers_common.queries.course_videos,
         views: teachers_common.queries.views,
       },
@@ -201,7 +208,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND %(views)s' % {
+      query='%(course_key)s AND %(course_videos)s AND %(views)s' % {
+        course_key: teachers_common.queries.course_key,
         course_videos: teachers_common.queries.course_videos,
         views: teachers_common.queries.views,
       },
@@ -236,7 +244,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND %(views)s' % {
+      query='%(course_key)s AND %(course_videos)s AND %(views)s' % {
+        course_key: teachers_common.queries.course_key,
         course_videos: teachers_common.queries.course_videos,
         views: teachers_common.queries.views,
       },
@@ -272,7 +281,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND %(complete_views)s' % {
+      query='%(course_key)s AND %(course_videos)s AND %(complete_views)s' % {
+        course_key: teachers_common.queries.course_key,
         course_videos: teachers_common.queries.course_videos,
         complete_views: teachers_common.queries.complete_views,
       },
@@ -297,7 +307,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND %(complete_views)s' % {
+      query='%(course_key)s AND %(course_videos)s AND %(complete_views)s' % {
+        course_key: teachers_common.queries.course_key,
         course_videos: teachers_common.queries.course_videos,
         complete_views: teachers_common.queries.complete_views,
       },
@@ -332,7 +343,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND %(complete_views)s' % {
+      query='%(course_key)s AND %(course_videos)s AND %(complete_views)s' % {
+        course_key: teachers_common.queries.course_key,
         course_videos: teachers_common.queries.course_videos,
         complete_views: teachers_common.queries.complete_views,
       },
@@ -366,7 +378,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND %(downloads)s' % {
+      query='%(course_key)s AND %(course_videos)s AND %(downloads)s' % {
+        course_key: teachers_common.queries.course_key,
         course_videos: teachers_common.queries.course_videos,
         downloads: teachers_common.queries.downloads,
       },
@@ -391,7 +404,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND %(downloads)s' % {
+      query='%(course_key)s AND %(course_videos)s AND %(downloads)s' % {
+        course_key: teachers_common.queries.course_key,
         course_videos: teachers_common.queries.course_videos,
         downloads: teachers_common.queries.downloads,
       },
@@ -426,7 +440,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(course_videos)s AND %(downloads)s' % {
+      query='%(course_key)s AND %(course_videos)s AND %(downloads)s' % {
+        course_key: teachers_common.queries.course_key,
         course_videos: teachers_common.queries.course_videos,
         downloads: teachers_common.queries.downloads,
       },
@@ -588,7 +603,8 @@ dashboard.new(
             type: 'count',
           },
         ],
-        query: '%(course_videos)s AND %(views)s' % {
+        query: '%(course_key)s AND %(course_videos)s AND %(views)s' % {
+          course_key: teachers_common.queries.course_key,
           course_videos: teachers_common.queries.course_videos,
           views: teachers_common.queries.views,
         },
@@ -655,7 +671,8 @@ dashboard.new(
         ],
         datasource: common.datasources.lrs,
         metrics: [utils.metrics.cardinality(common.fields.actor.account.name)],
-        query: '%(course_videos)s AND %(views)s' % {
+        query: '%(course_key)s AND %(course_videos)s AND %(views)s' % {
+          course_key: teachers_common.queries.course_key,
           course_videos: teachers_common.queries.course_videos,
           views: teachers_common.queries.views,
         },
@@ -678,7 +695,8 @@ dashboard.new(
         ],
         datasource: common.datasources.lrs,
         metrics: [utils.metrics.count],
-        query: '%(course_videos)s AND %(complete_views)s' % {
+        query: '%(course_key)s AND %(course_videos)s AND %(complete_views)s' % {
+          course_key: teachers_common.queries.course_key,
           course_videos: teachers_common.queries.course_videos,
           complete_views: teachers_common.queries.complete_views,
         },
@@ -701,7 +719,8 @@ dashboard.new(
         ],
         datasource: common.datasources.lrs,
         metrics: [utils.metrics.cardinality(common.fields.actor.account.name)],
-        query: '%(course_videos)s AND %(complete_views)s' % {
+        query: '%(course_key)s AND %(course_videos)s AND %(complete_views)s' % {
+          course_key: teachers_common.queries.course_key,
           course_videos: teachers_common.queries.course_videos,
           complete_views: teachers_common.queries.complete_views,
         },

--- a/src/dashboards/teachers/details.jsonnet
+++ b/src/dashboards/teachers/details.jsonnet
@@ -50,7 +50,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(video_iri)s AND verb.id:"%(verb_initialized)s"' % {
+      query='%(course_key)s AND %(video_iri)s AND verb.id:"%(verb_initialized)s"' % {
+        course_key: teachers_common.queries.course_key,
         video_iri: teachers_common.queries.video_iri,
         verb_initialized: common.fields.verb.id.initialized,
       },
@@ -75,7 +76,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(video_iri)s AND verb.id:"%(verb_initialized)s"' % {
+      query='%(course_key)s AND %(video_iri)s AND verb.id:"%(verb_initialized)s"' % {
+        course_key: teachers_common.queries.course_key,
         video_iri: teachers_common.queries.video_iri,
         verb_initialized: common.fields.verb.id.initialized,
       },
@@ -109,7 +111,8 @@ dashboard.new(
     elasticsearch.target(
       alias='Views',
       datasource=common.datasources.lrs,
-      query='%(video_iri)s AND %(views)s' % {
+      query='%(course_key)s AND %(video_iri)s AND %(views)s' % {
+        course_key: teachers_common.queries.course_key,
         video_iri: teachers_common.queries.video_iri,
         views: teachers_common.queries.views,
       },
@@ -121,7 +124,8 @@ dashboard.new(
     elasticsearch.target(
       alias='Complete views',
       datasource=common.datasources.lrs,
-      query='%(video_iri)s AND %(complete_views)s' % {
+      query='%(course_key)s AND %(video_iri)s AND %(complete_views)s' % {
+        course_key: teachers_common.queries.course_key,
         video_iri: teachers_common.queries.video_iri,
         complete_views: teachers_common.queries.complete_views,
       },
@@ -133,7 +137,8 @@ dashboard.new(
     elasticsearch.target(
       alias='Downloads',
       datasource=common.datasources.lrs,
-      query='%(video_iri)s AND %(downloads)s' % {
+      query='%(course_key)s AND %(video_iri)s AND %(downloads)s' % {
+        course_key: teachers_common.queries.course_key,
         video_iri: teachers_common.queries.video_iri,
         downloads: teachers_common.queries.downloads,
       },
@@ -162,7 +167,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(video_iri)s AND %(views)s' % {
+      query='%(course_key)s AND %(video_iri)s AND %(views)s' % {
+        course_key: teachers_common.queries.course_key,
         video_iri: teachers_common.queries.video_iri,
         views: teachers_common.queries.views,
       },
@@ -187,7 +193,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(video_iri)s AND %(views)s' % {
+      query='%(course_key)s AND %(video_iri)s AND %(views)s' % {
+        course_key: teachers_common.queries.course_key,
         video_iri: teachers_common.queries.video_iri,
         views: teachers_common.queries.views,
       },
@@ -223,7 +230,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(video_iri)s AND %(complete_views)s' % {
+      query='%(course_key)s AND %(video_iri)s AND %(complete_views)s' % {
+        course_key: teachers_common.queries.course_key,
         video_iri: teachers_common.queries.video_iri,
         complete_views: teachers_common.queries.complete_views,
       },
@@ -248,7 +256,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(video_iri)s AND %(complete_views)s' % {
+      query='%(course_key)s AND %(video_iri)s AND %(complete_views)s' % {
+        course_key: teachers_common.queries.course_key,
         video_iri: teachers_common.queries.video_iri,
         complete_views: teachers_common.queries.complete_views,
       },
@@ -284,7 +293,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(video_iri)s AND %(downloads)s' % {
+      query='%(course_key)s AND %(video_iri)s AND %(downloads)s' % {
+        course_key: teachers_common.queries.course_key,
         video_iri: teachers_common.queries.video_iri,
         downloads: teachers_common.queries.downloads,
       },
@@ -309,7 +319,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(video_iri)s AND %(downloads)s' % {
+      query='%(course_key)s AND %(video_iri)s AND %(downloads)s' % {
+        course_key: teachers_common.queries.course_key,
         video_iri: teachers_common.queries.video_iri,
         downloads: teachers_common.queries.downloads,
       },
@@ -376,7 +387,10 @@ dashboard.new(
           },
         ],
         metrics: [utils.metrics.count],
-        query: teachers_common.queries.video_iri,
+        query: '%(course_key)s AND %(video_iri)s' % {
+          course_key: teachers_common.queries.course_key,
+          video_iri: teachers_common.queries.video_iri,
+        },
         refId: 'A',
         timeField: '@timestamp',
       },
@@ -394,7 +408,10 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query=teachers_common.queries.video_iri,
+      query='%(course_key)s AND %(video_iri)s' % {
+        course_key: teachers_common.queries.course_key,
+        video_iri: teachers_common.queries.video_iri,
+      },
       metrics=[utils.metrics.count],
       bucketAggs=[
         {
@@ -428,7 +445,10 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query=teachers_common.queries.video_iri,
+      query='%(course_key)s AND %(video_iri)s' % {
+        course_key: teachers_common.queries.course_key,
+        video_iri: teachers_common.queries.video_iri,
+      },
       metrics=[utils.metrics.count],
       bucketAggs=[
         {
@@ -467,7 +487,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(video_iri)s AND %(interactions)s AND %(subtitle_enabled)s:true' % {
+      query='%(course_key)s AND %(video_iri)s AND %(interactions)s AND %(subtitle_enabled)s:true' % {
+        course_key: teachers_common.queries.course_key,
         video_iri: teachers_common.queries.video_iri,
         interactions: teachers_common.queries.interactions,
         subtitle_enabled: utils.functions.single_escape_string(common.fields.context.extensions.subtitle_enabled),
@@ -521,7 +542,8 @@ dashboard.new(
     targets: [
       {
         datasource: common.datasources.lrs,
-        query: '%(video_iri)s AND %(interactions)s' % {
+        query: '%(course_key)s AND %(video_iri)s AND %(interactions)s' % {
+          course_key: teachers_common.queries.course_key,
           video_iri: teachers_common.queries.video_iri,
           interactions: teachers_common.queries.interactions,
         },
@@ -560,7 +582,8 @@ dashboard.new(
   ).addTarget(
     elasticsearch.target(
       datasource=common.datasources.lrs,
-      query='%(video_iri)s AND %(interactions)s AND %(full_screen)s:true' % {
+      query='%(course_key)s AND %(video_iri)s AND %(interactions)s AND %(full_screen)s:true' % {
+        course_key: teachers_common.queries.course_key,
         video_iri: teachers_common.queries.video_iri,
         interactions: teachers_common.queries.interactions,
         full_screen: utils.functions.single_escape_string(common.fields.context.extensions.full_screen),
@@ -615,7 +638,8 @@ dashboard.new(
     targets: [
       {
         datasource: common.datasources.lrs,
-        query: '%(video_iri)s AND %(interactions)s' % {
+        query: '%(course_key)s AND %(video_iri)s AND %(interactions)s' % {
+          course_key: teachers_common.queries.course_key,
           video_iri: teachers_common.queries.video_iri,
           interactions: teachers_common.queries.interactions,
         },
@@ -691,7 +715,8 @@ dashboard.new(
     targets: [
       {
         datasource: common.datasources.lrs,
-        query: '%(video_iri)s AND %(interactions)s' % {
+        query: '%(course_key)s AND %(video_iri)s AND %(interactions)s' % {
+          course_key: teachers_common.queries.course_key,
           video_iri: teachers_common.queries.video_iri,
           interactions: teachers_common.queries.interactions,
         },
@@ -813,7 +838,8 @@ dashboard.new(
     targets: [
       {
         datasource: common.datasources.lrs,
-        query: '%(video_iri)s AND %(interactions)s' % {
+        query: '%(course_key)s AND %(video_iri)s AND %(interactions)s' % {
+          course_key: teachers_common.queries.course_key,
           video_iri: teachers_common.queries.video_iri,
           interactions: teachers_common.queries.interactions,
         },


### PR DESCRIPTION
## Purpose

Previously, queries for course and details dashboards were not explicitly scoped to a single course, potentially exposing analytics from multiple courses if a video would be reused.


## Proposal

This change ensures that dashboard queries are restricted to the context of the currently selected course.

_On a side note, improving the README and fixing a docker compose warning._

